### PR TITLE
faster Parse implementation

### DIFF
--- a/hexcolor.go
+++ b/hexcolor.go
@@ -1,27 +1,46 @@
 package hexcolor
 
 import (
-	"fmt"
+	"errors"
 	"image/color"
 )
 
 // Parse - parse hex string to image/color
-func Parse(hex string) (color.Color, error) {
+func Parse(hex string) (c color.RGBA, err error) {
 	// got this parsing code from here https://stackoverflow.com/a/54200713/1723695
-	var c color.RGBA
-	var err error
+
+	var errInvalidFormat = errors.New("invalid format")
+
 	c.A = 0xff
+
+	if hex[0] != '#' {
+		return c, errInvalidFormat
+	}
+
+	hexToByte := func(b byte) byte {
+		switch {
+		case b >= '0' && b <= '9':
+			return b - '0'
+		case b >= 'a' && b <= 'f':
+			return 10 + b - 'a'
+		case b >= 'A' && b <= 'F':
+			return 10 + b - 'A'
+		}
+		err = errInvalidFormat
+		return 0
+	}
+
 	switch len(hex) {
 	case 7:
-		_, err = fmt.Sscanf(hex, "#%02x%02x%02x", &c.R, &c.G, &c.B)
+		c.R = (hexToByte(hex[1]) << 4) + hexToByte(hex[2])
+		c.G = (hexToByte(hex[3]) << 4) + hexToByte(hex[4])
+		c.B = (hexToByte(hex[5]) << 4) + hexToByte(hex[6])
 	case 4:
-		_, err = fmt.Sscanf(hex, "#%1x%1x%1x", &c.R, &c.G, &c.B)
-		// Double the hex digits:
-		c.R *= 17
-		c.G *= 17
-		c.B *= 17
+		c.R = hexToByte(hex[1]) * 17
+		c.G = hexToByte(hex[2]) * 17
+		c.B = hexToByte(hex[3]) * 17
 	default:
-		err = fmt.Errorf("invalid length, must be 7 or 4")
+		err = errInvalidFormat
 	}
-	return c, err
+	return
 }

--- a/hexcolor_test.go
+++ b/hexcolor_test.go
@@ -46,3 +46,21 @@ func checkColor(t *testing.T, expected, actual color.Color) {
 		t.Fatalf("expected %3v but was %3v", expected, actual)
 	}
 }
+
+func benchmarkParse(s string, b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		Parse(s)
+	}
+}
+
+func BenchmarkParseLong(b *testing.B) {
+	benchmarkParse("#7fffd4", b)
+}
+
+func BenchmarkParseShort(b *testing.B) {
+	benchmarkParse("#123", b)
+}
+
+func BenchmarkParseErr(b *testing.B) {
+	benchmarkParse("foobar", b)
+}


### PR DESCRIPTION
fix #3


```
Old Parse:
BenchmarkParseLong-8             1000000              1201 ns/op
BenchmarkParseShort-8            2000000               987 ns/op
BenchmarkParseErr-8             10000000               173 ns/op

New Parse:
BenchmarkParseLong-8            30000000                41.1 ns/op
BenchmarkParseShort-8           30000000                40.1 ns/op
BenchmarkParseErr-8             30000000                35.8 ns/op

```
